### PR TITLE
API Optimization [FIX]

### DIFF
--- a/core/libs/meta/manager.php
+++ b/core/libs/meta/manager.php
@@ -33,6 +33,25 @@ class Manager
      */
     protected $di;
 
+    /**
+     * This is the cached metadata
+     *
+     * @var array $cachedModelMeta
+     */
+    protected static $cachedModelMeta = array();
+
+    /**
+     * This is the cached metadata of relationships.
+     *
+     * @var array $cachedRelationshipMeta
+     */
+    protected static $cachedRelationshipMeta = array();
+
+    /**
+     * This is the base path for the metadata.
+     *
+     * @var string
+     */
     public const basePath = '/app/metadata';
 
     /**
@@ -55,6 +74,10 @@ class Manager
      */
     public function getModelMeta($model)
     {
+        if (isset(self::$cachedModelMeta[$model])) {
+            return self::$cachedModelMeta[$model];
+        }
+
         $metadata = $this->di->get('fileHandler')->readFile(APP_PATH . self::basePath . '/model/' . $model . '.php');
         $metadata = $metadata[$model];
         $fields = $this->parseFields($metadata);
@@ -115,6 +138,8 @@ class Manager
             'acl' => (isset($metadata['acl']) ? $metadata['acl'] : array()),
         );
 
+        self::$cachedModelMeta[$model] = $modelMeta;
+
         return $modelMeta;
     }
 
@@ -129,6 +154,10 @@ class Manager
      */
     public function getRelationshipMeta($modelAlias, $relationshipName)
     {
+        if (isset(self::$cachedRelationshipMeta[$modelAlias][$relationshipName])) {
+            return self::$cachedRelationshipMeta[$modelAlias][$relationshipName];
+        }
+
         $modelMeta = $this->getModelMeta($modelAlias);
         $relMeta = [];
 
@@ -136,6 +165,7 @@ class Manager
             foreach ($related as $relName => $relDef) {
                 if ($relationshipName == $relName) {
                     $relMeta = $relDef;
+                    $relMeta['type'] = $relationshipType;
                     break;
                 }
             }
@@ -144,6 +174,8 @@ class Manager
         if (!$relMeta) {
             throw new \Gaia\Exception\Exception("No metadata found against relationship ". $relName);
         }
+
+        self::$cachedRelationshipMeta[$modelAlias][$relationshipName] = $relMeta;
 
         return $relMeta;
     }

--- a/core/mvc/controllers/RestController.php
+++ b/core/mvc/controllers/RestController.php
@@ -117,13 +117,6 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
     protected $accessibleProjects = array();
 
     /**
-     * This is the cached metadata
-     *
-     * @var array $cachedMeta
-     */
-    protected static $cachedMeta = array();
-
-    /**
      * Acl Map
      *
      * @var array $aclMap
@@ -347,7 +340,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
 
         $rels = isset($rels) ? explode(",", $rels) : array();
         foreach ($rels as $rel) {
-            $relationships[$rel] = $this->getRelationshipMeta($modelName, $rel);
+            $relationships[$rel] = $this->di->get('metaManager')->getRelationshipMeta($modelName, $rel);
         }
 
         return $relationships;
@@ -1033,7 +1026,8 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
             $data['baseModel']->setHydrateMode(Resultset::HYDRATE_ARRAYS);
 
             foreach ($data['baseModel'] as $values) {
-                $this->removeSecureFields($values);
+                $modelAlias = Util::extractClassFromNamespace($this->modelName);
+                $this->removeSecureFields($values, $modelAlias);
                 if (isset($params['fields']) && !empty($params['fields'])) {
                     $values = $this->updateFields($values, $params, $requireScalarFields);
                 }
@@ -1103,7 +1097,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
             }
 
             if (is_array($value)) {
-                $relDef = $this->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $attr);
+                $relDef = $this->di->get('metaManager')->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $attr);
                 if ($relDef['type'] == 'hasMany' || $relDef['type'] == 'hasManyToMany') {
                     if (!empty($value['id'])) {
                         $result[$values['id']][$attr][] = $value;
@@ -1169,7 +1163,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
                     $included = array();
                     if (isset($val['id'])) {
                         $jsonApiOrg['data'][$count]['relationships'][$attr] = array();
-                        $relationDefinition = $this->getRelationshipMeta($modelName, $attr);
+                        $relationDefinition = $this->di->get('metaManager')->getRelationshipMeta($modelName, $attr);
                         $relatedModelKey = 'relatedModel';
                         if ($relationDefinition['type'] == 'hasManyToMany') {
                             $relatedModelKey = 'secondaryModel';
@@ -1188,7 +1182,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
                             if (isset($object['id'])) {
                                 $included = array();
                                 $jsonApiOrg['data'][$count]['relationships'][$attr]['data'][$idx] = array();
-                                $relationDefinition = $this->getRelationshipMeta($modelName, $attr);
+                                $relationDefinition = $this->di->get('metaManager')->getRelationshipMeta($modelName, $attr);
                                 $relatedCount = 0;
                                 $relatedModelKey = 'relatedModel';
                                 if ($relationDefinition['type'] == 'hasManyToMany' && isset($relationDefinition['secondaryModel'])) {
@@ -1238,7 +1232,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
                     if (isset($val['id'])) {
                         $included = array();
                         $jsonApiOrg['data']['relationships'][$attr] = array();
-                        $relationDefinition = $this->getRelationshipMeta($modelName, $attr);
+                        $relationDefinition = $this->di->get('metaManager')->getRelationshipMeta($modelName, $attr);
                         $relatedCount = 0;
                         $relatedModelKey = 'relatedModel';
                         if ($relationDefinition['type'] == 'hasManyToMany') {
@@ -1257,7 +1251,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
                             if (isset($object['id'])) {
                                 $included = array();
                                 $jsonApiOrg['data']['relationships'][$attr]['data'][$idx] = array();
-                                $relationDefinition = $this->getRelationshipMeta($modelName, $attr);
+                                $relationDefinition = $this->di->get('metaManager')->getRelationshipMeta($modelName, $attr);
                                 $relatedCount = 0;
                                 $relatedModelKey = 'relatedModel';
                                 if ($relationDefinition['type'] == 'hasManyToMany') {
@@ -1319,8 +1313,9 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
      */
     public function setAllRelatedFieldsToBaseModel(&$result, $relData, $relName)
     {
-        $relMeta = $this->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $relName);
+        $relMeta = $this->di->get('metaManager')->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $relName);
         $relatedModelName = Util::extractClassFromNamespace($relMeta['relatedModel']);
+        $secondaryModelName = Util::extractClassFromNamespace($relMeta['secondaryModel']);
         $rhsKey = $relMeta['rhsKey'];
 
         //iterate each relationship
@@ -1328,6 +1323,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
             $modelId = $model[$relatedModelName][$rhsKey];
             if ($result[$modelId]) {
                 unset($model[$relatedModelName]);
+                $this->removeSecureFields($model, $secondaryModelName);
                 $result[$modelId][$relName][] = $model;
             }
         }
@@ -1344,7 +1340,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
     public function setSomeRelatedFieldsToBaseModel(&$result, $relData, $relName)
     {
         $relatedModel = [];
-        $relMeta = $this->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $relName);
+        $relMeta = $this->di->get('metaManager')->getRelationshipMeta(Util::extractClassFromNamespace($this->modelName), $relName);
 
         foreach ($relData as $model) {
             $lhsKey = $relMeta['lhsKey'];
@@ -1362,34 +1358,6 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
                 $result[$model[$rhsKey]][$relName][] = $secondaryModel;
             }
         }
-    }
-
-    /**
-     * This function is used to retrieve the relationship metadata for a model
-     *
-     * @param  string $modelName
-     * @param  string $rel
-     * @return array
-     */
-    final private function getRelationshipMeta($modelName, $rel)
-    {
-        if (isset(self::$cachedMeta[$modelName][$rel])) {
-            return self::$cachedMeta[$modelName][$rel];
-        }
-        $modelMetadata = $this->di->get('metaManager')->getModelMeta($modelName);
-
-        $relatedMetadata = array();
-        foreach ($modelMetadata['relationships'] as $relationType => $related) {
-            foreach ($related as $relName => $relDef) {
-                if ($relName == $rel) {
-                    $relatedMetadata = $relDef;
-                    $relatedMetadata['type'] = $relationType;
-                    break;
-                }
-            }
-        }
-        self::$cachedMeta[$modelName][$rel] = $relatedMetadata;
-        return $relatedMetadata;
     }
 
     /**
@@ -1635,11 +1603,13 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
      * Masks secure fields (like passwords) with asterisks in both model fields
      * and related model fields. Also handles nested relationships.
      *
-     * @param array &$values Reference to array of model values to process
+     * @param array  &$values    Reference to array of model values to process
+     * @param string $modelAlias The alias/name of the current model
+     *
+     * @return void
      */
-    final private function removeSecureFields(&$values)
+    final private function removeSecureFields(&$values, $modelAlias)
     {
-        $modelAlias = Util::extractClassFromNamespace($this->modelName);
         foreach ($values as $key => $value) {
             if (!is_array($value)) {
                 if ($this->isSecureField($modelAlias, $key)) {
@@ -1674,7 +1644,7 @@ class RestController extends \Phalcon\Mvc\Controller implements \Phalcon\Events\
     final private function isSecureField($modelName, $fieldName)
     {
         $modelMetadata = $this->di->get('metaManager')->getModelMeta($modelName);
-        return isset($modelMetadata['fields'][$fieldName]) && $modelMetadata['fields'][$fieldName]['secure'];
+        return isset($modelMetadata['fields'][$fieldName]['secure']) && $modelMetadata['fields'][$fieldName]['secure'];
     }
 
     /**

--- a/core/mvc/models/Model.php
+++ b/core/mvc/models/Model.php
@@ -207,7 +207,6 @@ class Model extends PhalconModel
 
         $this->query->prepareReadAllQuery($this->getModelPath(), $params, $this->relationship);
         $this->fireEvent("beforeQuery");
-
         $resultSets = $this->executeQuery($params, 'prepareReadAllQuery');
 
         $this->fireEvent("afterQuery");
@@ -314,9 +313,12 @@ class Model extends PhalconModel
             $this->query = $this->instantiateQuery($this->modelAlias, $parameters);
             $this->query->setClause($clause);
             $this->relationship = $this->bootstrapRelationship($parameters);
-            $this->relationship->setRelationshipFields($parameters['rels']);
+            $this->relationship->loadRequestedRelationships($parameters['rels']);
+            $this->relationship->setRelationshipFields($parameters['rels'], $this->query);
+            $this->fireEvent('beforeJoins');
             $this->relationship->prepareJoinsForQuery($parameters['rels'], $this->modelAlias, $this->query->getPhalconQueryBuilder());
             $this->query->{ $typeOfQueryToPerform}($this->getModelPath(), $parameters, $this->relationship);
+            $this->fireEvent('beforeQuery');
             $resultSets['baseModel'] = $this->executeModel($this->query);
             $baseModelIds = DataExtractor::extractModelIds($resultSets['baseModel']);
 
@@ -379,7 +381,7 @@ class Model extends PhalconModel
         //Prepare Join for model
         $hasManyRel = new HasMany($this->di);
         $relMeta['relatedKey'] = $relMeta['lhsKey'];
-        $hasManyRel->prepareJoin($relatedModelName, $relMeta, $secondaryModelName, 'left', $query->getPhalconQueryBuilder());
+        $hasManyRel->prepareJoin($relatedModelName, $relMeta, $secondaryModelName, 'left', $query->getPhalconQueryBuilder(), null, ['key' => $relatedModelName, 'keyToReplace' => "$relName$relatedModelName"]);
 
         //set default fields for relationship
         $relationship->setRelationshipFields($relParams['rels'], $query);
@@ -390,7 +392,9 @@ class Model extends PhalconModel
         
         // Execute Relationship.
         $query->prepareReadAllQuery($relMeta['secondaryModel'], $relParams, $relationship);
+        $this->fireEvent('beforeQuery');
         $result = $this->executeModel($query);
+        $this->fireEvent('afterQuery');
 
         //Update Base model where clause
         $relWheres = $baseModelQuery->getClause()->getWhereClause('translated', $relName);

--- a/core/mvc/models/relationships/HasManyToMany.php
+++ b/core/mvc/models/relationships/HasManyToMany.php
@@ -11,10 +11,10 @@ use Gaia\Libraries\Utils\Util;
 /**
  * This class represents HasManyToMany relationship.
  *
- * @author Rana Nouman <ranamnouman@gmail.com>
- * @package Foundation\Core\MVC\Models\Relationships
+ * @author   Rana Nouman <ranamnouman@gmail.com>
+ * @package  Foundation\Core\MVC\Models\Relationships
  * @category HasManyToMany
- * @license http://www.gnu.org/licenses/agpl.html AGPLv3
+ * @license  http://www.gnu.org/licenses/agpl.html AGPLv3
  */
 class HasManyToMany
 {
@@ -28,7 +28,7 @@ class HasManyToMany
     /**
      * HasManyToMany constructor.
      *
-     * @param \Phalcon\DiInterface  $di
+     * @param \Phalcon\DiInterface $di
      */
     function __construct(\Phalcon\Di\FactoryDefault $di)
     {
@@ -38,13 +38,13 @@ class HasManyToMany
     /**
      * This function prepares joins based on relationship meta and set that joins in query builder.
      *
-     * @param string $relationshipName
-     * @param array $relationshipMeta
-     * @param string $modelAlias
-     * @param string $joinType
+     * @param string                           $relationshipName
+     * @param array                            $relationshipMeta
+     * @param string                           $modelAlias
+     * @param string                           $joinType
      * @param \Phalcon\Mvc\Model\Query\Builder $queryBuilder
      */
-    public function prepareJoin($relationshipName, $relationshipMeta, $modelAlias, $joinType, $queryBuilder, $relConditions)
+    public function prepareJoin($relationshipName, $relationshipMeta, $modelAlias, $joinType, $queryBuilder, $relConditions = null)
     {
         // for a many-many relationshipMeta two joins are required
         $relatedModel = $relationshipMeta['relatedModel'];
@@ -85,8 +85,8 @@ class HasManyToMany
     /**
      * This function prepares where condition.
      * 
-     * @param array $relMeta
-     * @param array $whereClauses
+     * @param  array $relMeta
+     * @param  array $whereClauses
      * @return string
      */
     public function prepareWhere($relMeta, $whereClauses)
@@ -115,7 +115,7 @@ class HasManyToMany
     /**
      * This function returns fields related to given hasManyToMany relationship.
      * 
-     * @param string $relName Name of the relationship.
+     * @param  string $relName Name of the relationship.
      * @return array
      */
     public function getFields($relName)
@@ -130,10 +130,10 @@ class HasManyToMany
     /**
      * This function set all fields related to hasManyToMany relationship.
      * 
-     * @param array $parameters Relationship parameters.
-     * @param string $relName Name of the relationship.
-     * @param array $relMeta Relationship metadata.
-     * @param array $hasManyToManyRelationships
+     * @param array  $parameters                 Relationship parameters.
+     * @param string $relName                    Name of the relationship.
+     * @param array  $relMeta                    Relationship metadata.
+     * @param array  $hasManyToManyRelationships
      */
     public function setFields(&$parameters, $relName, $relMeta, $hasManyToManyRelationships)
     {
@@ -164,9 +164,8 @@ class HasManyToMany
      * This function change alias of relationship from a given query. 
      * e.g "skills.name : Emberjs" query for User model is requested so, it will change skills.name to Tag.name.
      * 
-     * @param array $relMeta Metadata of relationship.
-     * @param string $field Field of relationship.
-     * 
+     * @param array  $relMeta Metadata of relationship.
+     * @param string $field   Field of relationship.
      */
     public function changeAliasOfRel($relMeta, $field)
     {

--- a/core/mvc/models/relationships/HasOneAndManyBase.php
+++ b/core/mvc/models/relationships/HasOneAndManyBase.php
@@ -11,38 +11,38 @@ use Gaia\Core\MVC\Models\Relationship;
 /**
  * This class is base for hasOne, HasMany and belongsTo relationships.
  *
- * @author Rana Nouman <ranamnouman@gmail.com>
- * @package Foundation\Core\MVC\Models\Relationships
+ * @author   Rana Nouman <ranamnouman@gmail.com>
+ * @package  Foundation\Core\MVC\Models\Relationships
  * @category HasOneAndManyBase
- * @license http://www.gnu.org/licenses/agpl.html AGPLv3
+ * @license  http://www.gnu.org/licenses/agpl.html AGPLv3
  */
 class HasOneAndManyBase extends Relationship
 {
     /**
      * This function prepares join based on relationship meta and set that join in query builder.
      *
-     * @param string $relationshipName
-     * @param array $relationshipMeta
-     * @param string $modelAlias
-     * @param string $joinType
+     * @param string                           $relationshipName
+     * @param array                            $relationshipMeta
+     * @param string                           $modelAlias
+     * @param string                           $joinType
      * @param \Phalcon\Mvc\Model\Query\Builder $queryBuilder
      */
-    public function prepareJoin($relationshipName, $relationshipMeta, $modelAlias, $joinType, $queryBuilder, $relConditions)
+    public function prepareJoin($relationshipName, $relationshipMeta, $modelAlias, $joinType, $queryBuilder, $relConditions = null, $relConditionKey = null)
     {
         $relatedModel = $relationshipMeta['relatedModel'];
 
         // If an exclusive condition is defined then use that
         if (isset($relationshipMeta['conditionExclusive'])) {
             $relatedQuery = $relationshipMeta['conditionExclusive'];
-        }
-        else {
+        } else {
             $relatedQuery = $modelAlias . '.' . $relationshipMeta['primaryKey'] .
                 ' = ' . $relationshipName . '.' . $relationshipMeta['relatedKey'];
         }
 
         // if a condition is set in the metadata then use it
         if (isset($relationshipMeta['condition'])) {
-            $relatedQuery .= ' AND ' . $relationshipMeta['condition'];
+            $condition = str_replace($relConditionKey['keyToReplace'], $relConditionKey['key'], $relationshipMeta['condition']);
+            $relatedQuery .= ' AND ' . $condition;
         }
 
         if (isset($relConditions)) {


### PR DESCRIPTION
This PR contains the following changes:

1. The API was optimized from 6 seconds to approximately 200 seconds by caching the metadata of the model and related model. This also fixed the issue: **Fatal error: Maximum execution time of 30 seconds exceeded in /var/www/html/app/metadata/model/Milestone.php on line 7**.
2. Relationships are loaded when the query split flag is set to true.
3. A proper alias is used for the relationship (secondary model of the many-many relationship). This scenario appeared when the query was being split and the phalcon query got a mismatch in a key for the relationship (in joins).
